### PR TITLE
add some paredit-like commands for changing depth and moving

### DIFF
--- a/puni.el
+++ b/puni.el
@@ -1698,6 +1698,38 @@ argument means go forward."
       (puni-strict-backward-sexp 'skip-single-line-comments))))
 
 ;;;###autoload
+(defun puni-forward-sexp-or-up-list (&optional n)
+  "Go forward a sexp.
+This is the same as `puni-strict-forward-sexp', except that it
+jumps forward consecutive single-line comments, and will go over
+syntactic boundaries.
+
+With prefix argument N, go forward that many sexps.  Negative
+argument means go backward."
+  (interactive "^p")
+  (setq n (or n 1))
+  (if (< n 0) (puni-backward-sexp-or-up-list (- n))
+    (dotimes (_ n)
+      (or (puni-strict-forward-sexp 'skip-single-line-comments)
+          (puni-up-list)))))
+
+;;;###autoload
+(defun puni-backward-sexp-or-up-list (&optional n)
+  "Go backward a sexp.
+This is the same as `puni-strict-backward-sexp', except that it
+jumps backward consecutive single-line comments, and will go over
+syntactic boundaries.
+
+With prefix argument N, go backward that many sexps.  Negative
+argument means go forward."
+  (interactive "^p")
+  (setq n (or n 1))
+  (if (< n 0) (puni-forward-sexp-or-up-list (- n))
+    (dotimes (_ n)
+      (or (puni-strict-backward-sexp 'skip-single-line-comments)
+          (puni-up-list 'backward)))))
+
+;;;###autoload
 (defun puni-beginning-of-sexp ()
   "Go to the beginning of current sexp.
 This means go to the point after the opening delimiter.  If this
@@ -2207,6 +2239,24 @@ With positive prefix argument N, barf that many sexps."
      beg1 (- end2 open-delim-length close-delim-length)
      puni-blink-region-face)
     (setq deactivate-mark nil)))
+
+;;;###autoload
+(defun puni-splice-killing-backward ()
+  "Splice the list around point by removing its delimiters, and
+also kill all S-expressions before the point in the current list."
+  (interactive)
+  (puni-soft-delete-by-move
+   #'puni-beginning-of-list-around-point)
+  (puni-splice))
+
+;;;###autoload
+(defun puni-splice-killing-forward ()
+  "Splice the list around point by removing its delimiters, and
+also kill all S-expressions after the point in the current list."
+  (interactive)
+  (puni-soft-delete-by-move
+   #'puni-end-of-list-around-point)
+  (puni-splice))
 
 ;;;###autoload
 (defun puni-split ()

--- a/puni.el
+++ b/puni.el
@@ -1699,12 +1699,8 @@ argument means go forward."
 
 ;;;###autoload
 (defun puni-forward-sexp-or-up-list (&optional n)
-  "Go forward a sexp.
-This is the same as `puni-strict-forward-sexp', except that it
-jumps forward consecutive single-line comments, and will go over
-syntactic boundaries.
-
-With prefix argument N, go forward that many sexps.  Negative
+  "Go forward a sexp, or an ending delimiter if there's no sexp forward.
+With prefix argument N, do this that many times.  Negative
 argument means go backward."
   (interactive "^p")
   (setq n (or n 1))
@@ -1715,12 +1711,8 @@ argument means go backward."
 
 ;;;###autoload
 (defun puni-backward-sexp-or-up-list (&optional n)
-  "Go backward a sexp.
-This is the same as `puni-strict-backward-sexp', except that it
-jumps backward consecutive single-line comments, and will go over
-syntactic boundaries.
-
-With prefix argument N, go backward that many sexps.  Negative
+  "Go backward a sexp, or a starting delimiter if there's no sexp backward.
+With prefix argument N, do this that many times.  Negative
 argument means go forward."
   (interactive "^p")
   (setq n (or n 1))
@@ -2242,20 +2234,20 @@ With positive prefix argument N, barf that many sexps."
 
 ;;;###autoload
 (defun puni-splice-killing-backward ()
-  "Splice the list around point by removing its delimiters, and
-also kill all S-expressions before the point in the current list."
+  "Kill all sexps before point in the current list, then splice it.
+Splicing is done by removing the delimiters of the list."
   (interactive)
   (puni-soft-delete-by-move
-   #'puni-beginning-of-list-around-point)
+   #'puni-beginning-of-list-around-point nil nil 'kill)
   (puni-splice))
 
 ;;;###autoload
 (defun puni-splice-killing-forward ()
-  "Splice the list around point by removing its delimiters, and
-also kill all S-expressions after the point in the current list."
+  "Kill all sexps after point in the current list, then splice it.
+Splicing is done by removing the delimiters of the list."
   (interactive)
   (puni-soft-delete-by-move
-   #'puni-end-of-list-around-point)
+   #'puni-end-of-list-around-point nil nil 'kill)
   (puni-splice))
 
 ;;;###autoload

--- a/puni.el
+++ b/puni.el
@@ -2459,7 +2459,7 @@ like before wrapping.  BEG and END are integers, not markers."
                     ((eq n 'to-beg) most-negative-fixnum)
                     ((numberp n) n)
                     (t (user-error
-                        "expected 'to-end, 'to-beg, 'region, or integer as N, \
+                        "Expected 'to-end, 'to-beg, 'region, or integer as N, \
 got: %S"
                         n))))
            (beg (save-excursion
@@ -2489,7 +2489,7 @@ got: %S"
   "Wrap the following S-expression with parentheses.
 If a ‘C-u’ prefix argument is given, wrap all S-expressions
 following the point until the end of the buffer or of the
-enclosing list. If a numeric prefix argument N is given, wrap N
+enclosing list.  If a numeric prefix argument N is given, wrap N
 S-expressions.  Automatically indent the newly wrapped
 S-expression."
   (interactive "P")

--- a/puni.el
+++ b/puni.el
@@ -2459,7 +2459,8 @@ like before wrapping.  BEG and END are integers, not markers."
                     ((eq n 'to-beg) most-negative-fixnum)
                     ((numberp n) n)
                     (t (user-error
-                        "expected 'to-end, 'to-beg, 'region, or integer as N, got: %S"
+                        "expected 'to-end, 'to-beg, 'region, or integer as N, \
+got: %S"
                         n))))
            (beg (save-excursion
                   (if (>= n 0)


### PR DESCRIPTION
This adds puni-(forward|backward)-sexp-or-up-list, which move over the delimiter instead of stopping, and
puni-splice-killing-(backward|forward) which are similar to puni-raise, but keep all S-expression before/after the point, instead of just one.

This closes #39 