### PR TITLE
Allow C-w to work on inactive regions, like the stock one

### DIFF
--- a/puni.el
+++ b/puni.el
@@ -1484,7 +1484,7 @@ Continue? "))
 
 ;;;###autoload
 (defun puni-kill-region (beg end)
-  "Kill region.
+  "Kill region (from BEG to END).
 When this will cause unbalanced state, ask the user to confirm,
 unless `puni-confirm-when-delete-unbalanced-active-region'."
   (interactive "r")

--- a/puni.el
+++ b/puni.el
@@ -1483,6 +1483,19 @@ Continue? "))
     (user-error "No active region")))
 
 ;;;###autoload
+(defun puni-kill-region (beg end)
+  "Kill region.
+When this will cause unbalanced state, ask the user to confirm,
+unless `puni-confirm-when-delete-unbalanced-active-region'."
+  (interactive "r")
+  (when (or (not puni-confirm-when-delete-unbalanced-active-region)
+            (puni-region-balance-p beg end)
+            (y-or-n-p "Delete the region will cause unbalanced state.  \
+Continue? "))
+    (setq this-command 'kill-region)
+    (puni-delete-region beg end 'kill)))
+
+;;;###autoload
 (defun puni-kill-active-region ()
   "Kill active region.
 When this will cause unbalanced state, ask the user to confirm,
@@ -1491,12 +1504,7 @@ unless `puni-confirm-when-delete-unbalanced-active-region'."
   (if (use-region-p)
       (let ((beg (region-beginning))
             (end (region-end)))
-        (when (or (not puni-confirm-when-delete-unbalanced-active-region)
-                  (puni-region-balance-p beg end)
-                  (y-or-n-p "Delete the region will cause unbalanced state.  \
-Continue? "))
-          (setq this-command 'kill-region)
-          (puni-delete-region beg end 'kill)))
+        (puni-kill-region beg end))
     (user-error "No active region")))
 
 ;;;;; Char
@@ -2562,7 +2570,7 @@ S-expression."
     (define-key map (kbd "C-k") 'puni-kill-line)
     (define-key map (kbd "C-S-k") 'puni-backward-kill-line)
     (define-key map (kbd "C-c DEL") 'puni-force-delete)
-    (define-key map (kbd "C-w") 'puni-kill-active-region)
+    (define-key map (kbd "C-w") 'puni-kill-region)
     (define-key map (kbd "C-M-f") 'puni-forward-sexp)
     (define-key map (kbd "C-M-b") 'puni-backward-sexp)
     (define-key map (kbd "C-M-a") 'puni-beginning-of-sexp)


### PR DESCRIPTION
I've left the original command too, so no functionality should be lost. I believe the new one should be bound by default to keep the stock-like experience, but it would also make sense to keep the old one instead, to not change the current behavior.