### PR TITLE
Check for beginning of buffer in puni--backward-blanks

### DIFF
--- a/puni.el
+++ b/puni.el
@@ -189,7 +189,9 @@ than BOUND."
     (let ((from (point)))
       (while (and (or (null bound) (> (point) bound))
                   (or (puni--backward-syntax " " bound)
-                      (when (bolp) (forward-char -1) t))))
+                      (when (and (not (bobp))
+                                 (bolp))
+                        (forward-char -1) t))))
       (let ((to (point)))
         (unless (eq from to) to)))))
 


### PR DESCRIPTION
puni--backward-blanks previously did not check this condition which caused some functions (e.g. (puni-up-list)) to fail with an error message instead of returning nil as per normal.