### PR TITLE
fix: Make puni-kill-line properly respect kill-whole-line

### DIFF
--- a/puni.el
+++ b/puni.el
@@ -1644,7 +1644,7 @@ This respects the variable `kill-whole-line'."
         (puni-backward-kill-line (- n))
       (setq to (save-excursion (forward-line (or n 1))
                                (point)))
-      (unless (or kill-whole-line
+      (unless (or (and kill-whole-line (bolp))
                   ;; This is default behavior of Emacs: When the prefix
                   ;; argument is specified, always kill whole line.
                   n


### PR DESCRIPTION
Quoting from the documentation of `kill-line`:

> If option `kill-whole-line` is non-nil, then this command kills the
> whole line including its terminating newline, when used at the
> beginning of a line with no argument.

The "at the beginning of a line" is the important bit here. `kill-line` ensures this by checking `(and kill-whole-line (bolp))`, while `puni-kill-line` only checks `kill-whole-line` itself so far. Fix this by checking for the full condition.

Fixes: https://github.com/AmaiKinono/puni/issues/55