### PR TITLE
puni-kill-active-region: do Emacs default behavior if there's no active region

### DIFF
--- a/puni.el
+++ b/puni.el
@@ -1558,7 +1558,9 @@ rectangular region instead."
   (interactive)
   (if (use-region-p)
       (puni-kill-region)
-    (user-error "No active region")))
+    ;; Fall back to Emacs default behavior which is signaling an error or what
+    ;; `kill-region-dwim' defines (since Emacs 31).
+    (call-interactively #'kill-region)))
 
 ;;;;; Char
 


### PR DESCRIPTION
In Emacs 31, there's a new user option.
```
kill-region-dwim is a variable defined in ‘simple.el’.

Its value is ‘emacs-word’
Original value was nil

Behavior when ‘kill-region’ is invoked without an active region.
If set to nil (default), kill the region even if it is inactive,
signaling an error if there is no region.
If set to ‘emacs-word’, kill the last word as defined by the
current major mode.
If set to ‘unix-word’, kill the last word in the style of a shell like
Bash.  This ignores the major mode like ‘unix-word-rubout’ (which see).

  This variable was introduced, or its default value was changed, in
  version 31.1 of Emacs.
  You can customize this variable.
```
So when set to `emacs-word` (or `unix-word`) and you hit `C-w` (`kill-region`) while there is no active region, it will just kill the previous word.  That's a very nice feature.  However, it won't work with `puni-kill-active-region` which always signals an error when there's no active region.  This PR changes that so that erroring itself, we simply fall back to `kill-region`.