### PR TITLE
Add puni-wrap-pick

### DIFF
--- a/puni.el
+++ b/puni.el
@@ -2683,6 +2683,23 @@ S-expression."
    (puni--parse-interactive-argument-for-wrap n)
    "<" ">"))
 
+;;;###autoload
+(defun puni-wrap-pick (&optional n)
+  "Completing-read interface for wrapping S-expressions.
+If a ‘C-u’ prefix argument is given, wrap all S-expressions
+following the point until the end of the buffer or of the
+enclosing list.  If a numeric prefix argument N is given, wrap N
+S-expressions. Automatically indent the newly wrapped
+S-expression."
+  (interactive "P")
+  (let ((choice (completing-read "Choose a wrapper: "
+                                 '("Angle" "Curly" "Round" "Square"))))
+    (pcase choice
+      ("Angle" (puni-wrap-angle n))
+      ("Curly" (puni-wrap-curly n))
+      ("Round" (puni-wrap-round n))
+      ("Square" (puni-wrap-squaren n)))))
+
 ;;;; Puni mode
 
 ;;;###autoload


### PR DESCRIPTION
Completing-read function used for picking other wrapping functions.

Also supports the universal and numeric argument.

Points of discussion:

I think an annotation for this would be nice, but I don't know how to make these. Something like this:

|Candidate|Annotation|
|---------------|---------------|
|"Angle"|\<bar>|
|"Curly"|{bar}|
|"Round"|(bar)|
|"Square"|[bar]|

There's [this](https://eddrit.com/r/emacs/comments/uo5u19/completingread_annotations_to_align_or_not/) post, with a relevant link to [this Citar function](https://github.com/emacs-citar/citar/blob/9a6fc6da11ad2b475244cc4cbd51c77615e9aad3/citar-org.el#L246-L252).